### PR TITLE
Show line numbers when reading files

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,12 +22,12 @@ hide_client = hide.Client()
 By default, the client will connect to the Hide server running on `http://localhost:8080`. If you have Hide running on a different host or port, you can specify it when creating the client:
 
 ```python
-hide_client = hide.Client(base_url="https://my-hide-server:8080")
+hide_client = hide.Client(base_url="https://my-hide-server:8081")
 ```
 
 ## Creating a Project
 
-A project is a containerized development environment for a specific codebase. Creating a project involves cloning the repository and setting up a devcontainer. We can do this by calling the `create_project` method on the client:
+A project is a containerized development environment for a specific codebase. Creating a project consists of cloning the repository and setting up a devcontainer. We can do this by calling the `create_project` method on the client and passing a URL of the project on GitHub:
 
 ```python
 project = hide_client.create_project(
@@ -35,7 +35,7 @@ project = hide_client.create_project(
 )
 ```
 
-The [Tiny Math Service](https://github.com/artmoskvin/tiny-math-service) is a simple Python service that performs basic mathematical operations. It has a devcontainer configuration file (`.devcontainer.json`) that is used to create a development environment for the project.
+Here, we use the [Tiny Math Service](https://github.com/artmoskvin/tiny-math-service) which is a simple Python service that performs basic mathematical operations. It has a devcontainer configuration file (`.devcontainer.json`) that is used to create a development environment for the project.
 
 !!! note
 
@@ -61,13 +61,13 @@ project = hide_client.create_project(
 )
 ```
 
-Creating a project can take some time. Under the hood, Hide clones the repository, pulls the image, and installs the project dependencies.
+Creating a project can take some time. Under the hood, Hide clones the repository, pulls or builds the image, starts the container and installs the project dependencies.
 
 ## Using the Client
 
 ### Running Tasks
 
-Having created a project, we can now interact with it using the Hide client. You could notice that the devcontainer configuration contains a `customizations` section that defines a custom task called `test`. We can use this task to run tests for our project:
+Having created a project, we can now start working with it. You could notice that the devcontainer [configuration](https://github.com/artmoskvin/tiny-math-service/blob/main/.devcontainer.json) for the [Tiny Math Service](https://github.com/artmoskvin/tiny-math-service) contains a `customizations` section that defines a custom task called `test`. We can use this task to run tests for our project:
 
 ```python
 result = hide_client.run_task(project.id, alias="test")
@@ -76,15 +76,50 @@ print(result.stdOut)
 
 The print statement will output the test results.
 
-Aliases are convenient when referring to a frequently used command. Task API also allows us to run arbitrary shell commands in the project root by providing the command in the `command` parameter:
+Aliases are convenient when referring to frequently used commands. Running tasks is powered by Task API which also allows us to run arbitrary shell commands by providing the `command` parameter:
 
 ```python
 result = hide_client.run_task(project.id, command="pwd")
 print(result.stdOut)
 ```
 
-This will print the path to the project root directory.
+The tasks are executed from the project root so the print statement will output the path to the project root directory.
 
-### Updating Files
+### Reading and Updating Files
 
-TBA
+We can also read and update files in the project. For example, we can read the `maths.py` file and add a new endpoint in it. First, let's read the file:
+
+```python
+result = hide_client.get_file(project.id, path="my_tiny_service/api/routers/maths.py")
+print(result.content)
+```
+
+This will print the content of the `maths.py` file. 
+
+Coding agents often update files by generating diffs. Therefore it can be important to include line numbers when reading files. With Hide, we can include line numbers by setting the `show_line_numbers` parameter to `True`:
+
+```python
+result = hide_client.get_file(
+    project.id, path="my_tiny_service/api/routers/maths.py", show_line_numbers=True
+)
+
+print(result.content)
+```
+
+This will print the content of the `maths.py` file with line numbers.
+
+By default, Hide will show the first 100 lines of the file. We can change this by setting the `start_line` and `num_lines` parameters:
+
+```python
+result = hide_client.get_file(
+    project.id,
+    path="my_tiny_service/api/routers/maths.py",
+    show_line_numbers=True,
+    start_line=10,
+    num_lines=20,
+)
+
+print(result.content)
+```
+
+This will print the content of the `maths.py` file with 20 lines starting from line 10.

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -68,7 +68,33 @@ To read the contents of a specific file:
 
 This will return the contents of the file `example.txt` in your project's root directory.
 
-We are working on supporting different parameters for reading files, such as specifying a range of lines, or including the line numbers in the response. Stay tuned! :blush:
+Reading files supports different parameters such as specifying a range of lines, or including the line numbers in the response. To include the line numbers, set the `showLineNumbers` parameter to `true`:
+
+=== "curl"
+
+    ```bash
+    curl http://localhost:8080/projects/{project_id}/files/example.txt?showLineNumbers=true
+    ```
+
+=== "python"
+
+    ```python
+    # Coming soon
+    ```
+
+To specify a range of lines, set the `startLine` and `numLines` parameters:
+
+=== "curl"
+
+    ```bash
+    curl http://localhost:8080/projects/{project_id}/files/example.txt?startLine=10&numLines=20
+    ```
+
+=== "python"
+
+    ```python
+    # Coming soon
+    ```
 
 ### Updating a File
 

--- a/pkg/filemanager/manager_test.go
+++ b/pkg/filemanager/manager_test.go
@@ -1,0 +1,220 @@
+package filemanager_test
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/artmoskvin/hide/pkg/filemanager"
+)
+
+func TestNewReadProps(t *testing.T) {
+	tests := []struct {
+		name     string
+		props    []filemanager.ReadPropsSetter
+		expected filemanager.ReadProps
+	}{
+		{
+			name: "ShowLineNumbers",
+			props: []filemanager.ReadPropsSetter{
+				func(props *filemanager.ReadProps) {
+					props.ShowLineNumbers = true
+				},
+			},
+			expected: filemanager.ReadProps{
+				ShowLineNumbers: true,
+				StartLine:       filemanager.DefaultStartLine,
+				NumLines:        filemanager.DefaultNumLines,
+			},
+		},
+		{
+			name: "StartLine",
+			props: []filemanager.ReadPropsSetter{
+				func(props *filemanager.ReadProps) {
+					props.StartLine = 10
+				},
+			},
+			expected: filemanager.ReadProps{
+				ShowLineNumbers: filemanager.DefaultShowLineNumbers,
+				StartLine:       10,
+				NumLines:        filemanager.DefaultNumLines,
+			},
+		},
+		{
+			name: "NumLines",
+			props: []filemanager.ReadPropsSetter{
+				func(props *filemanager.ReadProps) {
+					props.NumLines = 20
+				},
+			},
+			expected: filemanager.ReadProps{
+				ShowLineNumbers: filemanager.DefaultShowLineNumbers,
+				StartLine:       filemanager.DefaultStartLine,
+				NumLines:        20,
+			},
+		},
+		{
+			name: "All",
+			props: []filemanager.ReadPropsSetter{
+				func(props *filemanager.ReadProps) {
+					props.ShowLineNumbers = true
+					props.StartLine = 10
+					props.NumLines = 20
+				},
+			},
+			expected: filemanager.ReadProps{
+				ShowLineNumbers: true,
+				StartLine:       10,
+				NumLines:        20,
+			},
+		},
+		{
+			name:  "Default",
+			props: []filemanager.ReadPropsSetter{},
+			expected: filemanager.ReadProps{
+				ShowLineNumbers: filemanager.DefaultShowLineNumbers,
+				StartLine:       filemanager.DefaultStartLine,
+				NumLines:        filemanager.DefaultNumLines,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := filemanager.NewReadProps(tt.props...)
+			if actual != tt.expected {
+				t.Errorf("Expected %+v, got %+v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestFileManagerImpl_ReadFile_Success(t *testing.T) {
+	files := fstest.MapFS{
+		"test.txt": {Data: []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10")},
+	}
+
+	tests := []struct {
+		name     string
+		fs       fs.FS
+		filePath string
+		props    filemanager.ReadPropsSetter
+		expected filemanager.File
+	}{
+		{
+			name:     "ShowLineNumbers = true",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 2
+				props.NumLines = 3
+			},
+			expected: filemanager.File{
+				Path:    "test.txt",
+				Content: "2:line2\n3:line3\n4:line4\n",
+			},
+		},
+		{
+			name:     "ShowLineNumbers = false",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = false
+				props.StartLine = 4
+				props.NumLines = 4
+			},
+			expected: filemanager.File{
+				Path:    "test.txt",
+				Content: "line4\nline5\nline6\nline7\n",
+			},
+		},
+		{
+			name:     "NumLines = 0",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 2
+				props.NumLines = 0
+			},
+			expected: filemanager.File{
+				Path:    "test.txt",
+				Content: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm := filemanager.NewFileManager()
+			actual, err := fm.ReadFile(tt.fs, tt.filePath, filemanager.NewReadProps(tt.props))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if actual != tt.expected {
+				t.Errorf("Expected %+v, got %+v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestFileManagerImpl_ReadFile_Failure(t *testing.T) {
+	files := fstest.MapFS{
+		"test.txt": {Data: []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10")},
+	}
+
+	tests := []struct {
+		name     string
+		fs       fs.FS
+		filePath string
+		props    filemanager.ReadPropsSetter
+		expected string
+	}{
+		{
+			name:     "StartLine < 1",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 0
+				props.NumLines = 1
+			},
+			expected: "Start line must be greater than or equal to 1",
+		},
+		{
+			name:     "NumLines < 0",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 1
+				props.NumLines = -1
+			},
+			expected: "Number of lines must be greater than or equal to 0",
+		},
+		{
+			name:     "Failed to read file",
+			fs:       fstest.MapFS{},
+			filePath: "test.txt",
+			props:    func(props *filemanager.ReadProps) {},
+			expected: "Failed to open file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm := filemanager.NewFileManager()
+			_, err := fm.ReadFile(tt.fs, tt.filePath, filemanager.NewReadProps(tt.props))
+			if err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.expected) {
+				t.Errorf("Expected error to contain '%s', got %s", tt.expected, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/filemanager/manager_test.go
+++ b/pkg/filemanager/manager_test.go
@@ -144,6 +144,34 @@ func TestFileManagerImpl_ReadFile_Success(t *testing.T) {
 				Content: "",
 			},
 		},
+		{
+			name:     "If StartLine + NumLines > number of lines then show all lines",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 5
+				props.NumLines = 10
+			},
+			expected: filemanager.File{
+				Path:    "test.txt",
+				Content: " 5:line5\n 6:line6\n 7:line7\n 8:line8\n 9:line9\n10:line10\n",
+			},
+		},
+		{
+			name:     "Line numbers are padded with spaces",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.ShowLineNumbers = true
+				props.StartLine = 5
+				props.NumLines = 10
+			},
+			expected: filemanager.File{
+				Path:    "test.txt",
+				Content: " 5:line5\n 6:line6\n 7:line7\n 8:line8\n 9:line9\n10:line10\n",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -178,19 +206,24 @@ func TestFileManagerImpl_ReadFile_Failure(t *testing.T) {
 			fs:       files,
 			filePath: "test.txt",
 			props: func(props *filemanager.ReadProps) {
-				props.ShowLineNumbers = true
 				props.StartLine = 0
-				props.NumLines = 1
 			},
 			expected: "Start line must be greater than or equal to 1",
+		},
+		{
+			name:     "StartLine > number of lines",
+			fs:       files,
+			filePath: "test.txt",
+			props: func(props *filemanager.ReadProps) {
+				props.StartLine = 11
+			},
+			expected: "Start line must be less than or equal to 10",
 		},
 		{
 			name:     "NumLines < 0",
 			fs:       files,
 			filePath: "test.txt",
 			props: func(props *filemanager.ReadProps) {
-				props.ShowLineNumbers = true
-				props.StartLine = 1
 				props.NumLines = -1
 			},
 			expected: "Number of lines must be greater than or equal to 0",

--- a/pkg/filemanager/mocks/mock_manager.go
+++ b/pkg/filemanager/mocks/mock_manager.go
@@ -1,0 +1,36 @@
+package mocks
+
+import (
+	"io/fs"
+
+	"github.com/artmoskvin/hide/pkg/filemanager"
+)
+
+// MockFileManager is a mock of the filemanager.FileManager interface for testing
+type MockFileManager struct {
+	CreateFileFunc func(path string, content string) (filemanager.File, error)
+	ReadFileFunc   func(fileSystem fs.FS, path string, props filemanager.ReadProps) (filemanager.File, error)
+	UpdateFileFunc func(path string, content string) (filemanager.File, error)
+	DeleteFileFunc func(path string) error
+	ListFilesFunc  func(rootPath string) ([]filemanager.File, error)
+}
+
+func (m *MockFileManager) CreateFile(path string, content string) (filemanager.File, error) {
+	return m.CreateFileFunc(path, content)
+}
+
+func (m *MockFileManager) ReadFile(fileSystem fs.FS, path string, props filemanager.ReadProps) (filemanager.File, error) {
+	return m.ReadFileFunc(fileSystem, path, props)
+}
+
+func (m *MockFileManager) UpdateFile(path string, content string) (filemanager.File, error) {
+	return m.UpdateFileFunc(path, content)
+}
+
+func (m *MockFileManager) DeleteFile(path string) error {
+	return m.DeleteFileFunc(path)
+}
+
+func (m *MockFileManager) ListFiles(rootPath string) ([]filemanager.File, error) {
+	return m.ListFilesFunc(rootPath)
+}

--- a/pkg/handlers/read_file.go
+++ b/pkg/handlers/read_file.go
@@ -2,8 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/artmoskvin/hide/pkg/filemanager"
 	"github.com/artmoskvin/hide/pkg/project"
@@ -17,6 +20,28 @@ type ReadFileHandler struct {
 func (h ReadFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	projectId := r.PathValue("id")
 	filePath := r.PathValue("path")
+	queryParams := r.URL.Query()
+
+	showLineNumbers, err := parseBoolQueryParam(queryParams, "showLineNumbers", filemanager.DefaultShowLineNumbers)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	startLine, err := parseIntQueryParam(queryParams, "startLine", filemanager.DefaultStartLine)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	numLines, err := parseIntQueryParam(queryParams, "numLines", filemanager.DefaultNumLines)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	project, err := h.Manager.GetProject(projectId)
 
@@ -25,14 +50,52 @@ func (h ReadFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, err := h.FileManager.ReadFile(os.DirFS(project.Path), filePath)
+	file, err := h.FileManager.ReadFile(os.DirFS(project.Path), filePath, filemanager.NewReadProps(
+		func(props *filemanager.ReadProps) {
+			props.ShowLineNumbers = showLineNumbers
+			props.StartLine = startLine
+			props.NumLines = numLines
+		},
+	))
 
 	if err != nil {
-		http.Error(w, "Failed to read file", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Failed to read file: %s", err), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(file)
+}
+
+func parseIntQueryParam(params url.Values, paramName string, defaultValue int) (int, error) {
+	param := params.Get(paramName)
+
+	if param == "" {
+		return defaultValue, nil
+	}
+
+	value, err := strconv.Atoi(param)
+
+	if err != nil {
+		return 0, fmt.Errorf("Failed to parse %s: %w", paramName, err)
+	}
+
+	return value, nil
+}
+
+func parseBoolQueryParam(params url.Values, paramName string, defaultValue bool) (bool, error) {
+	param := params.Get(paramName)
+
+	if param == "" {
+		return defaultValue, nil
+	}
+
+	value, err := strconv.ParseBool(param)
+
+	if err != nil {
+		return false, fmt.Errorf("Failed to parse %s: %w", paramName, err)
+	}
+
+	return value, nil
 }

--- a/pkg/handlers/read_file_test.go
+++ b/pkg/handlers/read_file_test.go
@@ -1,0 +1,187 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/artmoskvin/hide/pkg/filemanager"
+	filemanager_mocks "github.com/artmoskvin/hide/pkg/filemanager/mocks"
+	"github.com/artmoskvin/hide/pkg/handlers"
+	"github.com/artmoskvin/hide/pkg/project"
+	project_mocks "github.com/artmoskvin/hide/pkg/project/mocks"
+)
+
+func TestReadFileHandler_Success(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		expectedFile filemanager.File
+	}{
+		{
+			name:  "Read file with default params",
+			query: "",
+			expectedFile: filemanager.File{
+				Path:    "test.txt",
+				Content: "line1\nline2\nline3\n",
+			},
+		},
+		{
+			name:  "Read file with showLineNumbers=true",
+			query: "showLineNumbers=true",
+			expectedFile: filemanager.File{
+				Path:    "test.txt",
+				Content: "1:line1\n2:line2\n3:line3\n",
+			},
+		},
+		{
+			name:  "Read file with startLine=2",
+			query: "startLine=2",
+			expectedFile: filemanager.File{
+				Path:    "test.txt",
+				Content: "2:line2\n3:line3\n",
+			},
+		},
+		{
+			name:  "Read file with numLines=2",
+			query: "numLines=2",
+			expectedFile: filemanager.File{
+				Path:    "test.txt",
+				Content: "line1\nline2\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &project_mocks.MockProjectManager{
+				GetProjectFunc: func(projectId string) (project.Project, error) {
+					return project.Project{}, nil
+				},
+			}
+
+			mockFileManager := &filemanager_mocks.MockFileManager{
+				ReadFileFunc: func(fileSystem fs.FS, path string, props filemanager.ReadProps) (filemanager.File, error) {
+					return tt.expectedFile, nil
+				},
+			}
+
+			handler := handlers.ReadFileHandler{Manager: mockManager, FileManager: mockFileManager}
+
+			request, _ := http.NewRequest("GET", "/projects/123/files/test.txt?"+tt.query, nil)
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", response.Code)
+			}
+
+			var respFile filemanager.File
+			if err := json.NewDecoder(response.Body).Decode(&respFile); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if respFile != tt.expectedFile {
+				t.Errorf("Expected file %+v, got %+v", tt.expectedFile, respFile)
+			}
+		})
+	}
+}
+
+func TestReadFileHandler_Fails_WithInvalidQueryParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		expectedCode int
+	}{
+		{
+			name:         "Read file with invalid showLineNumbers param",
+			query:        "showLineNumbers=invalid",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Read file with invalid startLine param",
+			query:        "startLine=invalid",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Read file with invalid numLines param",
+			query:        "numLines=invalid",
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &project_mocks.MockProjectManager{
+				GetProjectFunc: func(projectId string) (project.Project, error) {
+					return project.Project{}, nil
+				},
+			}
+
+			handler := handlers.ReadFileHandler{Manager: mockManager, FileManager: filemanager.NewFileManager()}
+
+			request, _ := http.NewRequest("GET", "/projects/123/files/test.txt?"+tt.query, nil)
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, response.Code)
+				t.Errorf("Body: %s", response.Body.String())
+			}
+		})
+	}
+}
+
+func TestReadFileHandler_Fails_WhenProjectNotFound(t *testing.T) {
+	t.Run("Read file with invalid project ID", func(t *testing.T) {
+		mockManager := &project_mocks.MockProjectManager{
+			GetProjectFunc: func(projectId string) (project.Project, error) {
+				return project.Project{}, errors.New("project not found")
+			},
+		}
+
+		handler := handlers.ReadFileHandler{Manager: mockManager, FileManager: filemanager.NewFileManager()}
+
+		request, _ := http.NewRequest("GET", "/projects/123/files/test.txt", nil)
+		response := httptest.NewRecorder()
+
+		handler.ServeHTTP(response, request)
+
+		if response.Code != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", response.Code)
+		}
+	})
+}
+
+func TestReadFileHandler_Fails_WhenReadFileFails(t *testing.T) {
+	t.Run("Read file with invalid file path", func(t *testing.T) {
+		mockManager := &project_mocks.MockProjectManager{
+			GetProjectFunc: func(projectId string) (project.Project, error) {
+				return project.Project{}, nil
+			},
+		}
+
+		mockFileManager := &filemanager_mocks.MockFileManager{
+			ReadFileFunc: func(fileSystem fs.FS, path string, props filemanager.ReadProps) (filemanager.File, error) {
+				return filemanager.File{}, errors.New("file not found")
+			},
+		}
+
+		handler := handlers.ReadFileHandler{Manager: mockManager, FileManager: mockFileManager}
+
+		request, _ := http.NewRequest("GET", "/projects/123/files/invalid.txt", nil)
+		response := httptest.NewRecorder()
+
+		handler.ServeHTTP(response, request)
+
+		if response.Code != http.StatusInternalServerError {
+			t.Errorf("Expected status 500, got %d", response.Code)
+		}
+	})
+}


### PR DESCRIPTION
# Changelog

- Add ReadProps for filemanager.ReadFile:
  - ShowLineNumbers: bool (default false)
  - StartLine: int (default 1)
  - NumLine: int (default 100)
- Update API for reading files
- Update documentation
  - Quickstart
  - Files API