### PR TITLE
Add symbol search

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ var runCmd = &cobra.Command{
 			WithUpdateFileHandler(handlers.UpdateFileHandler{ProjectManager: projectManager}).
 			WithDeleteFileHandler(handlers.DeleteFileHandler{ProjectManager: projectManager}).
 			WithSearchFileHandler(handlers.SearchFilesHandler{ProjectManager: projectManager}).
-			WithSearchSymbolsHandler(handlers.NewSearchSymbolsHandler(projectManager, lspService)).
+			WithSearchSymbolsHandler(handlers.NewSearchSymbolsHandler(projectManager)).
 			Build()
 
 		addr := fmt.Sprintf("127.0.0.1:%d", port)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,7 +23,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 const (
@@ -104,7 +103,7 @@ var runCmd = &cobra.Command{
 		languageDetector := lsp.NewFileExtensionBasedLanguageDetector()
 		diagnosticsStore := lsp.NewDiagnosticsStore()
 		clientPool := lsp.NewClientPool()
-		lspService := lsp.NewService(languageDetector, lspServerExecutables, diagnosticsStore, clientPool, []protocol.SymbolKind{protocol.SymbolKindField, protocol.SymbolKindVariable})
+		lspService := lsp.NewService(languageDetector, lspServerExecutables, diagnosticsStore, clientPool)
 		projectManager := project.NewProjectManager(containerRunner, projectStore, projectsDir, fileManager, lspService, languageDetector, random.String)
 
 		router := handlers.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -118,6 +118,7 @@ var runCmd = &cobra.Command{
 			WithUpdateFileHandler(handlers.UpdateFileHandler{ProjectManager: projectManager}).
 			WithDeleteFileHandler(handlers.DeleteFileHandler{ProjectManager: projectManager}).
 			WithSearchFileHandler(handlers.SearchFilesHandler{ProjectManager: projectManager}).
+			WithSearchSymbolsHandler(handlers.NewSearchSymbolsHandler(projectManager, lspService)).
 			Build()
 
 		addr := fmt.Sprintf("127.0.0.1:%d", port)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 const (
@@ -103,7 +104,7 @@ var runCmd = &cobra.Command{
 		languageDetector := lsp.NewFileExtensionBasedLanguageDetector()
 		diagnosticsStore := lsp.NewDiagnosticsStore()
 		clientPool := lsp.NewClientPool()
-		lspService := lsp.NewService(languageDetector, lspServerExecutables, diagnosticsStore, clientPool)
+		lspService := lsp.NewService(languageDetector, lspServerExecutables, diagnosticsStore, clientPool, []protocol.SymbolKind{protocol.SymbolKindField, protocol.SymbolKindVariable})
 		projectManager := project.NewProjectManager(containerRunner, projectStore, projectsDir, fileManager, lspService, languageDetector, random.String)
 
 		router := handlers.

--- a/pkg/handlers/router.go
+++ b/pkg/handlers/router.go
@@ -66,6 +66,11 @@ func (r *Router) WithSearchFileHandler(handler SearchFilesHandler) *Router {
 	return r
 }
 
+func (r *Router) WithSearchSymbolsHandler(handler SearchSymbolsHandler) *Router {
+	r.Handle("/projects/{id}/search", handler).Queries("type", "symbol", "query", "").Methods("GET")
+	return r
+}
+
 func (r *Router) Build() *mux.Router {
 	return r.Router
 }

--- a/pkg/handlers/search_symbols.go
+++ b/pkg/handlers/search_symbols.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/artmoskvin/hide/pkg/lsp"
 	"github.com/artmoskvin/hide/pkg/project"
 )
 
@@ -16,12 +15,11 @@ const MaxLimit = 100
 const DefaultLimit = 10
 
 type SearchSymbolsHandler struct {
-	pm         project.Manager
-	lspService lsp.Service
+	pm project.Manager
 }
 
-func NewSearchSymbolsHandler(pm project.Manager, lspService lsp.Service) SearchSymbolsHandler {
-	return SearchSymbolsHandler{pm: pm, lspService: lspService}
+func NewSearchSymbolsHandler(pm project.Manager) SearchSymbolsHandler {
+	return SearchSymbolsHandler{pm: pm}
 }
 
 func (h SearchSymbolsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/pkg/handlers/search_symbols.go
+++ b/pkg/handlers/search_symbols.go
@@ -37,6 +37,18 @@ func SearchSymbolsLimit(n int) SearchSymbolsOptions {
 	}
 }
 
+func IncludeSymbols(symbols ...protocol.SymbolKind) SearchSymbolsOptions {
+	return func(opts *searchSymbolsOptions) {
+		opts.symbolFilter = lsp.NewIncludeSymbolFilter(symbols...)
+	}
+}
+
+func ExcludedSymbols(symbols ...protocol.SymbolKind) SearchSymbolsOptions {
+	return func(opts *searchSymbolsOptions) {
+		opts.symbolFilter = lsp.NewExcludeSymbolFilter(symbols...)
+	}
+}
+
 func NewSearchSymbolsHandler(pm project.Manager, opts ...SearchSymbolsOptions) SearchSymbolsHandler {
 	options := &searchSymbolsOptions{
 		maxLimit:     100,

--- a/pkg/handlers/search_symbols.go
+++ b/pkg/handlers/search_symbols.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/artmoskvin/hide/pkg/model"
+	"github.com/artmoskvin/hide/pkg/project"
+)
+
+type SearchSymbolsHandler struct {
+	pm         project.Manager
+	lspService lsp.Service
+}
+
+func NewSearchSymbolsHandler(pm project.Manager, lspService lsp.Service) SearchSymbolsHandler {
+	return SearchSymbolsHandler{pm: pm, lspService: lspService}
+}
+
+func (h SearchSymbolsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	projectID, err := getProjectID(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid project ID: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		http.Error(w, "query not specified", http.StatusBadRequest)
+		return
+	}
+
+	proj, err := h.pm.GetProject(r.Context(), projectID)
+	if err != nil {
+		var projectNotFoundError *project.ProjectNotFoundError
+		if errors.As(err, &projectNotFoundError) {
+			http.Error(w, projectNotFoundError.Error(), http.StatusNotFound)
+			return
+		}
+
+		http.Error(w, fmt.Sprintf("failed to get project: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	symbols, err := h.lspService.GetWorkspaceSymbols(model.NewContextWithProject(r.Context(), &proj), query)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get workspace symbols: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(symbols)
+}
+
+func removeFilePrefix(fileURL string) (string, error) {
+	u, err := url.Parse(fileURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("not a file URL")
+	}
+	return filepath.FromSlash(u.Path), nil
+}

--- a/pkg/handlers/search_symbols_test.go
+++ b/pkg/handlers/search_symbols_test.go
@@ -1,0 +1,148 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/artmoskvin/hide/pkg/handlers"
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/artmoskvin/hide/pkg/model"
+	"github.com/artmoskvin/hide/pkg/project"
+	"github.com/artmoskvin/hide/pkg/project/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchSymbolsHandler_ServeHTTP(t *testing.T) {
+	symbols := []lsp.SymbolInfo{
+		newSymbolInfo("symbol1", "kind1", "path1"),
+		newSymbolInfo("symbol2", "kind2", "path2"),
+	}
+
+	symbolJson, _ := json.Marshal(symbols[0])
+	symbolsJson, _ := json.Marshal(symbols)
+
+	tests := []struct {
+		name              string
+		target            string
+		mockSearchSymbols func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error)
+		wantStatusCode    int
+		wantBody          string
+	}{
+		{
+			name:   "success",
+			target: "/projects/123/search?type=symbol&query=test-query",
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return symbols, nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody:       string(symbolsJson),
+		},
+		{
+			name:   "success with limit",
+			target: "/projects/123/search?type=symbol&query=test-query&limit=1",
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return symbols[:1], nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody:       string(symbolJson),
+		},
+		{
+			name:   "success with limit higher than number of symbols",
+			target: fmt.Sprintf("/projects/123/search?type=symbol&query=test-query&limit=%d", len(symbols)+1),
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return symbols, nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody:       string(symbolsJson),
+		},
+		{
+			name:   "invalid limit",
+			target: "/projects/123/search?type=symbol&query=test-query&limit=invalid",
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return nil, nil
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "invalid limit invalid",
+		},
+		{
+			name:   "limit too large",
+			target: fmt.Sprintf("/projects/123/search?type=symbol&query=test-query&limit=%d", handlers.MaxLimit+1),
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return nil, nil
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "limit must be between 1 and 100",
+		},
+		{
+			name:   "limit too small",
+			target: fmt.Sprintf("/projects/123/search?type=symbol&query=test-query&limit=%d", handlers.MinLimit-1),
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return nil, nil
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "limit must be between 1 and 100",
+		},
+		{
+			name:   "project not found",
+			target: "/projects/123/search?type=symbol&query=test-query",
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return nil, project.NewProjectNotFoundError(projectId)
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantBody:       "project 123 not found",
+		},
+		{
+			name:   "internal server error",
+			target: "/projects/123/search?type=symbol&query=test-query",
+			mockSearchSymbols: func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+				return nil, errors.New("internal error")
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "failed to get workspace symbols: internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &mocks.MockProjectManager{
+				SearchSymbolsFunc: tt.mockSearchSymbols,
+			}
+
+			handler := handlers.NewSearchSymbolsHandler(mockManager)
+			router := handlers.NewRouter().WithSearchSymbolsHandler(handler).Build()
+
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatusCode, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantBody)
+		})
+	}
+}
+
+func newSymbolInfo(name, kind, path string) lsp.SymbolInfo {
+	return lsp.SymbolInfo{
+		Name: name,
+		Kind: kind,
+		Location: lsp.Location{
+			Path: path,
+			Range: lsp.Range{
+				Start: lsp.Position{
+					Line:      1,
+					Character: 1,
+				},
+				End: lsp.Position{
+					Line:      2,
+					Character: 2,
+				},
+			},
+		},
+	}
+}

--- a/pkg/lsp/client.go
+++ b/pkg/lsp/client.go
@@ -26,6 +26,7 @@ func (h *lspHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 }
 
 type Client interface {
+	GetWorkspaceSymbols(ctx context.Context, params protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error)
 	Initialize(ctx context.Context, params protocol.InitializeParams) (protocol.InitializeResult, error)
 	NotifyInitialized(ctx context.Context) error
 	NotifyDidOpen(ctx context.Context, params protocol.DidOpenTextDocumentParams) error
@@ -48,6 +49,12 @@ func NewClient(server Process, diagnosticsChannel chan protocol.PublishDiagnosti
 	}
 	conn := NewConnection(context.Background(), server.ReadWriteCloser(), jsonrpc2.HandlerWithError(handler.Handle))
 	return &ClientImpl{conn: conn, server: server, diagnosticsChannel: diagnosticsChannel}
+}
+
+func (c *ClientImpl) GetWorkspaceSymbols(ctx context.Context, params protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	var result []protocol.SymbolInformation
+	err := c.conn.Call(ctx, "workspace/symbol", params, &result)
+	return result, err
 }
 
 func (c *ClientImpl) Initialize(ctx context.Context, params protocol.InitializeParams) (protocol.InitializeResult, error) {

--- a/pkg/lsp/mocks/mock_client.go
+++ b/pkg/lsp/mocks/mock_client.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/stretchr/testify/mock"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+var _ lsp.Client = (*MockClient)(nil)
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) GetWorkspaceSymbols(ctx context.Context, params protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]protocol.SymbolInformation), args.Error(1)
+}
+
+func (m *MockClient) Initialize(ctx context.Context, params protocol.InitializeParams) (protocol.InitializeResult, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(protocol.InitializeResult), args.Error(1)
+}
+
+func (m *MockClient) NotifyInitialized(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockClient) NotifyDidOpen(ctx context.Context, params protocol.DidOpenTextDocumentParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockClient) NotifyDidClose(ctx context.Context, params protocol.DidCloseTextDocumentParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockClient) Shutdown(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/pkg/lsp/mocks/mock_client_pool.go
+++ b/pkg/lsp/mocks/mock_client_pool.go
@@ -1,0 +1,37 @@
+package mocks
+
+import (
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ lsp.ClientPool = (*MockClientPool)(nil)
+
+type MockClientPool struct {
+	mock.Mock
+}
+
+func (m *MockClientPool) Get(projectId lsp.ProjectId, languageId lsp.LanguageId) (lsp.Client, bool) {
+	args := m.Called(projectId, languageId)
+	return args.Get(0).(lsp.Client), args.Bool(1)
+}
+
+func (m *MockClientPool) GetAllForProject(projectId lsp.ProjectId) (map[lsp.LanguageId]lsp.Client, bool) {
+	args := m.Called(projectId)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1)
+	}
+	return args.Get(0).(map[lsp.LanguageId]lsp.Client), args.Bool(1)
+}
+
+func (m *MockClientPool) Set(projectId lsp.ProjectId, languageId lsp.LanguageId, client lsp.Client) {
+	m.Called(projectId, languageId, client)
+}
+
+func (m *MockClientPool) Delete(projectId lsp.ProjectId, languageId lsp.LanguageId) {
+	m.Called(projectId, languageId)
+}
+
+func (m *MockClientPool) DeleteAllForProject(projectId lsp.ProjectId) {
+	m.Called(projectId)
+}

--- a/pkg/lsp/mocks/mock_service.go
+++ b/pkg/lsp/mocks/mock_service.go
@@ -24,7 +24,7 @@ func (m *MockLspService) StopServer(ctx context.Context, languageId lsp.Language
 	return args.Error(0)
 }
 
-func (m *MockLspService) GetWorkspaceSymbols(ctx context.Context, query string) ([]lsp.SymbolInfo, error) {
+func (m *MockLspService) GetWorkspaceSymbols(ctx context.Context, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error) {
 	args := m.Called(ctx, query)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/pkg/lsp/mocks/mock_service.go
+++ b/pkg/lsp/mocks/mock_service.go
@@ -1,0 +1,53 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/artmoskvin/hide/pkg/model"
+	"github.com/stretchr/testify/mock"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type MockLspService struct {
+	mock.Mock
+}
+
+func (m *MockLspService) StartServer(ctx context.Context, languageId lsp.LanguageId) error {
+	args := m.Called(ctx, languageId)
+	return args.Error(0)
+}
+
+func (m *MockLspService) StopServer(ctx context.Context, languageId lsp.LanguageId) error {
+	args := m.Called(ctx, languageId)
+	return args.Error(0)
+}
+
+func (m *MockLspService) GetWorkspaceSymbols(ctx context.Context, query string) ([]lsp.SymbolInfo, error) {
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]lsp.SymbolInfo), args.Error(1)
+}
+
+func (m *MockLspService) NotifyDidOpen(ctx context.Context, file model.File) error {
+	args := m.Called(ctx, file)
+	return args.Error(0)
+}
+
+func (m *MockLspService) NotifyDidClose(ctx context.Context, file model.File) error {
+	args := m.Called(ctx, file)
+	return args.Error(0)
+}
+
+func (m *MockLspService) GetDiagnostics(ctx context.Context, file model.File) ([]protocol.Diagnostic, error) {
+	args := m.Called(ctx, file)
+	return args.Get(0).([]protocol.Diagnostic), args.Error(1)
+}
+
+func (m *MockLspService) CleanupProject(ctx context.Context, projectId lsp.ProjectId) error {
+	args := m.Called(ctx, projectId)
+	return args.Error(0)
+}

--- a/pkg/lsp/model.go
+++ b/pkg/lsp/model.go
@@ -1,0 +1,85 @@
+package lsp
+
+import (
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type SymbolInfo struct {
+	Name     string   `json:"name"`
+	Kind     string   `json:"kind"`
+	Location Location `json:"location"`
+}
+
+type Location struct {
+	Path  string `json:"path"`
+	Range Range  `json:"range"`
+}
+
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+type Position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+func symbolKindToString(kind protocol.SymbolKind) string {
+	switch kind {
+	case protocol.SymbolKindFile:
+		return "File"
+	case protocol.SymbolKindModule:
+		return "Module"
+	case protocol.SymbolKindNamespace:
+		return "Namespace"
+	case protocol.SymbolKindPackage:
+		return "Package"
+	case protocol.SymbolKindClass:
+		return "Class"
+	case protocol.SymbolKindMethod:
+		return "Method"
+	case protocol.SymbolKindProperty:
+		return "Property"
+	case protocol.SymbolKindField:
+		return "Field"
+	case protocol.SymbolKindConstructor:
+		return "Constructor"
+	case protocol.SymbolKindEnum:
+		return "Enum"
+	case protocol.SymbolKindInterface:
+		return "Interface"
+	case protocol.SymbolKindFunction:
+		return "Function"
+	case protocol.SymbolKindVariable:
+		return "Variable"
+	case protocol.SymbolKindConstant:
+		return "Constant"
+	case protocol.SymbolKindString:
+		return "String"
+	case protocol.SymbolKindNumber:
+		return "Number"
+	case protocol.SymbolKindBoolean:
+		return "Boolean"
+	case protocol.SymbolKindArray:
+		return "Array"
+	case protocol.SymbolKindObject:
+		return "Object"
+	case protocol.SymbolKindKey:
+		return "Key"
+	case protocol.SymbolKindNull:
+		return "Null"
+	case protocol.SymbolKindEnumMember:
+		return "EnumMember"
+	case protocol.SymbolKindStruct:
+		return "Struct"
+	case protocol.SymbolKindEvent:
+		return "Event"
+	case protocol.SymbolKindOperator:
+		return "Operator"
+	case protocol.SymbolKindTypeParameter:
+		return "TypeParameter"
+	default:
+		return "Unknown"
+	}
+}

--- a/pkg/lsp/service_test.go
+++ b/pkg/lsp/service_test.go
@@ -1,0 +1,149 @@
+package lsp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/artmoskvin/hide/pkg/lsp"
+	"github.com/artmoskvin/hide/pkg/lsp/mocks"
+	"github.com/artmoskvin/hide/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestService_GetWorkspaceSymbols(t *testing.T) {
+	aSymbol := protocol.SymbolInformation{Name: "test-name", Kind: protocol.SymbolKindClass, Location: protocol.Location{URI: "file:///test/project/test-uri", Range: protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 1, Character: 1}}}}
+
+	ignoredKind := protocol.SymbolKindField
+	ignoredSymbol := protocol.SymbolInformation{Name: "test-name", Kind: ignoredKind, Location: protocol.Location{URI: "file:///test/project/test-uri", Range: protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 1, Character: 1}}}}
+
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		query           string
+		mockSetup       func(*mocks.MockClientPool)
+		symbolsToIgnore []protocol.SymbolKind
+		wantSymbols     []lsp.SymbolInfo
+		wantErr         string
+	}{
+		{
+			name:  "success",
+			ctx:   model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				client.On("GetWorkspaceSymbols", mock.MatchedBy(isContext), protocol.WorkspaceSymbolParams{Query: "test-query"}).Return([]protocol.SymbolInformation{aSymbol}, nil)
+
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			wantSymbols: []lsp.SymbolInfo{{Name: "test-name", Kind: "Class", Location: lsp.Location{Path: "test-uri", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 2, Character: 1}}}}},
+		},
+		{
+			name:      "project not in context",
+			ctx:       context.Background(),
+			query:     "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {},
+			wantErr:   "project not found in context",
+		},
+		{
+			name:        "client not found",
+			ctx:         model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}),
+			query:       "test-query",
+			mockSetup:   func(m *mocks.MockClientPool) { m.On("GetAllForProject", "project-id").Return(nil, false) },
+			wantSymbols: nil,
+			wantErr:     "",
+		},
+		{
+			name: "context cancelled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}))
+				cancel()
+
+				return ctx
+			}(),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			wantSymbols: nil,
+			wantErr:     "context cancelled",
+		},
+		{
+			name:  "client error",
+			ctx:   model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				client.On("GetWorkspaceSymbols", mock.MatchedBy(isContext), protocol.WorkspaceSymbolParams{Query: "test-query"}).Return(nil, errors.New("test-error"))
+
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			wantErr: "test-error",
+		},
+		{
+			name:  "symbols ignored",
+			ctx:   model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				client.On("GetWorkspaceSymbols", mock.MatchedBy(isContext), protocol.WorkspaceSymbolParams{Query: "test-query"}).Return([]protocol.SymbolInformation{aSymbol, ignoredSymbol}, nil)
+
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			symbolsToIgnore: []protocol.SymbolKind{ignoredKind},
+			wantSymbols:     []lsp.SymbolInfo{{Name: "test-name", Kind: "Class", Location: lsp.Location{Path: "test-uri", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 2, Character: 1}}}}},
+		},
+		{
+			name:  "fail to remove file prefix",
+			ctx:   model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "/test/project"}),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				client.On("GetWorkspaceSymbols", mock.MatchedBy(isContext), protocol.WorkspaceSymbolParams{Query: "test-query"}).Return([]protocol.SymbolInformation{{Name: "test-name", Kind: protocol.SymbolKindClass, Location: protocol.Location{URI: "/test/project/test-uri", Range: protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 1, Character: 1}}}}}, nil)
+
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			wantErr: "failed to remove file prefix from URI",
+		},
+		{
+			name:  "fail to get relative path of file",
+			ctx:   model.NewContextWithProject(context.Background(), &model.Project{Id: "project-id", Path: "invalid-path"}),
+			query: "test-query",
+			mockSetup: func(m *mocks.MockClientPool) {
+				client := &mocks.MockClient{}
+				client.On("GetWorkspaceSymbols", mock.MatchedBy(isContext), protocol.WorkspaceSymbolParams{Query: "test-query"}).Return([]protocol.SymbolInformation{aSymbol}, nil)
+
+				m.On("GetAllForProject", "project-id").Return(map[lsp.LanguageId]lsp.Client{lsp.LanguageId("test-lang"): client}, true)
+			},
+			wantErr: "failed to get relative path of file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClientPool := &mocks.MockClientPool{}
+			tt.mockSetup(mockClientPool)
+
+			service := lsp.NewService(nil, nil, nil, mockClientPool, tt.symbolsToIgnore)
+
+			symbols, err := service.GetWorkspaceSymbols(tt.ctx, tt.query)
+
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSymbols, symbols)
+			}
+
+		})
+	}
+}
+
+func isContext(ctx interface{}) bool {
+	_, ok := ctx.(context.Context)
+	return ok
+}

--- a/pkg/lsp/symbols.go
+++ b/pkg/lsp/symbols.go
@@ -1,0 +1,30 @@
+package lsp
+
+import (
+	"slices"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type SymbolFilter struct {
+	include []protocol.SymbolKind
+	exclude []protocol.SymbolKind
+}
+
+func NewIncludeSymbolFilter(include ...protocol.SymbolKind) SymbolFilter {
+	return SymbolFilter{include: include}
+}
+
+func NewExcludeSymbolFilter(exclude ...protocol.SymbolKind) SymbolFilter {
+	return SymbolFilter{exclude: exclude}
+}
+func (f *SymbolFilter) shouldExcludeSymbol(symbol protocol.SymbolInformation) bool {
+	return slices.Contains(f.exclude, symbol.Kind)
+}
+
+func (f *SymbolFilter) shouldIncludeSymbol(symbol protocol.SymbolInformation) bool {
+	if len(f.include) == 0 {
+		return true
+	}
+	return slices.Contains(f.include, symbol.Kind)
+}

--- a/pkg/model/file.go
+++ b/pkg/model/file.go
@@ -55,6 +55,7 @@ func (f *File) GetContent() string {
 	return content.String()
 }
 
+// GetLine returns the line with the given line number. Line numbers are 1-based.
 func (f *File) GetLine(lineNumber int) Line {
 	if lineNumber < 1 || lineNumber > len(f.Lines) {
 		return Line{}
@@ -63,6 +64,7 @@ func (f *File) GetLine(lineNumber int) Line {
 	return f.Lines[lineNumber-1]
 }
 
+// GetLineRange returns the lines between start and end (exclusive). Line numbers are 1-based.
 func (f *File) GetLineRange(start, end int) []Line {
 	// Convert to 0-based indexing
 	start -= 1
@@ -79,10 +81,16 @@ func (f *File) GetLineRange(start, end int) []Line {
 	return f.Lines[start:end]
 }
 
+// WithLineRange returns a new File with the lines between start and end (exclusive). Line numbers are 1-based.
 func (f *File) WithLineRange(start, end int) *File {
 	return &File{Path: f.Path, Lines: f.GetLineRange(start, end)}
 }
 
+func (f *File) WithPath(path string) *File {
+	return &File{Path: path, Lines: f.Lines}
+}
+
+// ReplaceLineRange replaces the lines between start and end (exclusive) with the given content. Line numbers are 1-based.
 func (f *File) ReplaceLineRange(start, end int, content string) (*File, error) {
 	if start == end {
 		return f, nil
@@ -113,6 +121,7 @@ func (f *File) ReplaceLineRange(start, end int, content string) (*File, error) {
 	return &File{Path: f.Path, Lines: result}, nil
 }
 
+// NewFile creates a new File from the given path and content. Content is split into lines. Line numbers are 1-based.
 func NewFile(path string, content string) (*File, error) {
 	lines, err := NewLines(content)
 
@@ -123,6 +132,7 @@ func NewFile(path string, content string) (*File, error) {
 	return &File{Path: path, Lines: lines}, nil
 }
 
+// NewLines splits the given content into lines. Line numbers are 1-based.
 func NewLines(content string) ([]Line, error) {
 	var lines []Line
 

--- a/pkg/project/manager.go
+++ b/pkg/project/manager.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -43,19 +45,20 @@ type TaskResult struct {
 }
 
 type Manager interface {
-	CreateProject(ctx context.Context, request CreateProjectRequest) <-chan result.Result[model.Project]
-	GetProject(ctx context.Context, projectId model.ProjectId) (model.Project, error)
-	GetProjects(ctx context.Context) ([]*model.Project, error)
-	DeleteProject(ctx context.Context, projectId model.ProjectId) <-chan result.Empty
-	ResolveTaskAlias(ctx context.Context, projectId model.ProjectId, alias string) (devcontainer.Task, error)
-	CreateTask(ctx context.Context, projectId model.ProjectId, command string) (TaskResult, error)
+	ApplyPatch(ctx context.Context, projectId, path, patch string) (*model.File, error)
 	Cleanup(ctx context.Context) error
 	CreateFile(ctx context.Context, projectId, path, content string) (*model.File, error)
-	ReadFile(ctx context.Context, projectId, path string) (*model.File, error)
-	UpdateFile(ctx context.Context, projectId, path, content string) (*model.File, error)
+	CreateProject(ctx context.Context, request CreateProjectRequest) <-chan result.Result[model.Project]
+	CreateTask(ctx context.Context, projectId model.ProjectId, command string) (TaskResult, error)
 	DeleteFile(ctx context.Context, projectId, path string) error
+	DeleteProject(ctx context.Context, projectId model.ProjectId) <-chan result.Empty
+	GetProject(ctx context.Context, projectId model.ProjectId) (model.Project, error)
+	GetProjects(ctx context.Context) ([]*model.Project, error)
 	ListFiles(ctx context.Context, projectId string, showHidden bool) ([]*model.File, error)
-	ApplyPatch(ctx context.Context, projectId, path, patch string) (*model.File, error)
+	ReadFile(ctx context.Context, projectId, path string) (*model.File, error)
+	ResolveTaskAlias(ctx context.Context, projectId model.ProjectId, alias string) (devcontainer.Task, error)
+	SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error)
+	UpdateFile(ctx context.Context, projectId, path, content string) (*model.File, error)
 	UpdateLines(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error)
 }
 
@@ -508,6 +511,51 @@ func (pm ManagerImpl) UpdateLines(ctx context.Context, projectId, path string, l
 	return file, nil
 }
 
+func (pm ManagerImpl) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error) {
+	log.Debug().Str("projectId", projectId).Str("query", query).Msg("Searching symbols")
+
+	project, err := pm.GetProject(ctx, projectId)
+	if err != nil {
+		log.Error().Err(err).Str("projectId", projectId).Msg("Failed to get project")
+		return nil, fmt.Errorf("Failed to get project with id %s: %w", projectId, err)
+	}
+
+	symbols, err := pm.lspService.GetWorkspaceSymbols(model.NewContextWithProject(ctx, &project), query)
+	if err != nil {
+		log.Error().Err(err).Str("projectId", projectId).Msg("failed to get workspace symbols")
+		return nil, fmt.Errorf("failed to get workspace symbols: %w", err)
+	}
+
+	result := make([]*model.File, 0, len(symbols))
+	for _, symbol := range symbols {
+		filePath, err := removeFilePrefix(symbol.Location.URI)
+		if err != nil {
+			log.Error().Err(err).Str("projectId", projectId).Msg("failed to remove file prefix from URI")
+			return nil, fmt.Errorf("failed to remove file prefix from URI: %w", err)
+		}
+
+		ctx = model.NewContextWithProject(ctx, &project)
+		file, err := pm.fileManager.ReadFile(ctx, afero.NewOsFs(), filePath)
+
+		if err != nil {
+			log.Error().Err(err).Str("projectId", projectId).Msg("failed to read file")
+			return nil, fmt.Errorf("failed to read file: %w", err)
+		}
+
+		relPath, err := filepath.Rel(project.Path, filePath)
+		if err != nil {
+			log.Error().Err(err).Str("projectId", projectId).Str("path", filePath).Msg("failed to get relative path of file")
+			return nil, fmt.Errorf("failed to get relative path of file: %w", err)
+		}
+
+		result = append(result, file.WithPath(relPath).WithLineRange(int(symbol.Location.Range.Start.Line)+1, int(symbol.Location.Range.End.Line)+2))
+	}
+
+	log.Debug().Str("projectId", projectId).Str("query", query).Msgf("Found %d symbols", len(result))
+
+	return result, nil
+}
+
 func (pm ManagerImpl) createProjectDir(path string) error {
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return fmt.Errorf("Failed to create project directory: %w", err)
@@ -625,4 +673,15 @@ func parseGitignore(content string) []string {
 	}
 
 	return patterns
+}
+
+func removeFilePrefix(fileURL string) (string, error) {
+	u, err := url.Parse(fileURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("not a file URL")
+	}
+	return filepath.FromSlash(u.Path), nil
 }

--- a/pkg/project/manager.go
+++ b/pkg/project/manager.go
@@ -55,7 +55,7 @@ type Manager interface {
 	ListFiles(ctx context.Context, projectId string, showHidden bool) ([]*model.File, error)
 	ReadFile(ctx context.Context, projectId, path string) (*model.File, error)
 	ResolveTaskAlias(ctx context.Context, projectId model.ProjectId, alias string) (devcontainer.Task, error)
-	SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error)
+	SearchSymbols(ctx context.Context, projectId model.ProjectId, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error)
 	UpdateFile(ctx context.Context, projectId, path, content string) (*model.File, error)
 	UpdateLines(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error)
 }
@@ -509,7 +509,7 @@ func (pm ManagerImpl) UpdateLines(ctx context.Context, projectId, path string, l
 	return file, nil
 }
 
-func (pm ManagerImpl) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
+func (pm ManagerImpl) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error) {
 	log.Debug().Str("projectId", projectId).Str("query", query).Msg("Searching symbols")
 
 	project, err := pm.GetProject(ctx, projectId)
@@ -524,7 +524,7 @@ func (pm ManagerImpl) SearchSymbols(ctx context.Context, projectId model.Project
 	default:
 	}
 
-	symbols, err := pm.lspService.GetWorkspaceSymbols(model.NewContextWithProject(ctx, &project), query)
+	symbols, err := pm.lspService.GetWorkspaceSymbols(model.NewContextWithProject(ctx, &project), query, symbolFilter)
 	if err != nil {
 		log.Error().Err(err).Str("projectId", projectId).Msg("failed to get workspace symbols")
 		return nil, fmt.Errorf("failed to get workspace symbols: %w", err)

--- a/pkg/project/manager.go
+++ b/pkg/project/manager.go
@@ -518,6 +518,12 @@ func (pm ManagerImpl) SearchSymbols(ctx context.Context, projectId model.Project
 		return nil, fmt.Errorf("failed to get project with id %s: %w", projectId, err)
 	}
 
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context cancelled")
+	default:
+	}
+
 	symbols, err := pm.lspService.GetWorkspaceSymbols(model.NewContextWithProject(ctx, &project), query)
 	if err != nil {
 		log.Error().Err(err).Str("projectId", projectId).Msg("failed to get workspace symbols")

--- a/pkg/project/manager_test.go
+++ b/pkg/project/manager_test.go
@@ -191,7 +191,7 @@ func TestManagerImpl_CreateTask_ExecError(t *testing.T) {
 	}
 }
 
-func TestManagerImpl_GetWorkspaceSymbols(t *testing.T) {
+func TestManagerImpl_SearchSymbols(t *testing.T) {
 	symbols := []lsp.SymbolInfo{
 		{Name: "symbol1", Kind: "kind1", Location: lsp.Location{Path: "path1", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 1}, End: lsp.Position{Line: 2, Character: 2}}}},
 		{Name: "symbol2", Kind: "kind2", Location: lsp.Location{Path: "path2", Range: lsp.Range{Start: lsp.Position{Line: 3, Character: 3}, End: lsp.Position{Line: 4, Character: 4}}}},

--- a/pkg/project/manager_test.go
+++ b/pkg/project/manager_test.go
@@ -198,14 +198,15 @@ func TestManagerImpl_SearchSymbols(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		store     map[string]*model.Project
-		mockSetup func(*lsp_mocks.MockLspService)
-		context   context.Context
-		projectId string
-		query     string
-		want      []lsp.SymbolInfo
-		wantErr   string
+		name         string
+		store        map[string]*model.Project
+		mockSetup    func(*lsp_mocks.MockLspService)
+		context      context.Context
+		projectId    string
+		query        string
+		symbolFilter lsp.SymbolFilter
+		want         []lsp.SymbolInfo
+		wantErr      string
 	}{
 		{
 			name: "success",
@@ -266,7 +267,7 @@ func TestManagerImpl_SearchSymbols(t *testing.T) {
 			tt.mockSetup(lspService)
 			pm := project.NewProjectManager(nil, project.NewInMemoryStore(tt.store), "/tmp", nil, lspService, nil, nil)
 
-			symbols, err := pm.SearchSymbols(tt.context, tt.projectId, tt.query)
+			symbols, err := pm.SearchSymbols(tt.context, tt.projectId, tt.query, tt.symbolFilter)
 
 			if tt.wantErr != "" {
 				assert.Error(t, err)

--- a/pkg/project/mocks/mock_manager.go
+++ b/pkg/project/mocks/mock_manager.go
@@ -12,19 +12,20 @@ import (
 
 // MockProjectManager is a mock of the project.Manager interface for testing
 type MockProjectManager struct {
-	CreateProjectFunc    func(ctx context.Context, request project.CreateProjectRequest) <-chan result.Result[model.Project]
-	GetProjectFunc       func(ctx context.Context, projectId string) (model.Project, error)
-	GetProjectsFunc      func(ctx context.Context) ([]*model.Project, error)
-	DeleteProjectFunc    func(ctx context.Context, projectId string) <-chan result.Empty
-	ResolveTaskAliasFunc func(ctx context.Context, projectId string, alias string) (devcontainer.Task, error)
-	CreateTaskFunc       func(ctx context.Context, projectId string, command string) (project.TaskResult, error)
+	ApplyPatchFunc       func(ctx context.Context, projectId, path, patch string) (*model.File, error)
 	CleanupFunc          func(ctx context.Context) error
 	CreateFileFunc       func(ctx context.Context, projectId, path, content string) (*model.File, error)
-	ReadFileFunc         func(ctx context.Context, projectId, path string) (*model.File, error)
-	UpdateFileFunc       func(ctx context.Context, projectId, path, content string) (*model.File, error)
+	CreateProjectFunc    func(ctx context.Context, request project.CreateProjectRequest) <-chan result.Result[model.Project]
+	CreateTaskFunc       func(ctx context.Context, projectId string, command string) (project.TaskResult, error)
 	DeleteFileFunc       func(ctx context.Context, projectId, path string) error
+	DeleteProjectFunc    func(ctx context.Context, projectId string) <-chan result.Empty
+	GetProjectFunc       func(ctx context.Context, projectId string) (model.Project, error)
+	GetProjectsFunc      func(ctx context.Context) ([]*model.Project, error)
 	ListFilesFunc        func(ctx context.Context, projectId string, showHidden bool) ([]*model.File, error)
-	ApplyPatchFunc       func(ctx context.Context, projectId, path, patch string) (*model.File, error)
+	ReadFileFunc         func(ctx context.Context, projectId, path string) (*model.File, error)
+	ResolveTaskAliasFunc func(ctx context.Context, projectId string, alias string) (devcontainer.Task, error)
+	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error)
+	UpdateFileFunc       func(ctx context.Context, projectId, path, content string) (*model.File, error)
 	UpdateLinesFunc      func(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error)
 }
 
@@ -82,4 +83,8 @@ func (m *MockProjectManager) ApplyPatch(ctx context.Context, projectId, path, pa
 
 func (m *MockProjectManager) UpdateLines(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error) {
 	return m.UpdateLinesFunc(ctx, projectId, path, lineDiff)
+}
+
+func (m *MockProjectManager) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error) {
+	return m.SearchSymbolsFunc(ctx, projectId, query)
 }

--- a/pkg/project/mocks/mock_manager.go
+++ b/pkg/project/mocks/mock_manager.go
@@ -25,7 +25,7 @@ type MockProjectManager struct {
 	ListFilesFunc        func(ctx context.Context, projectId string, showHidden bool) ([]*model.File, error)
 	ReadFileFunc         func(ctx context.Context, projectId, path string) (*model.File, error)
 	ResolveTaskAliasFunc func(ctx context.Context, projectId string, alias string) (devcontainer.Task, error)
-	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error)
+	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error)
 	UpdateFileFunc       func(ctx context.Context, projectId, path, content string) (*model.File, error)
 	UpdateLinesFunc      func(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error)
 }
@@ -86,6 +86,6 @@ func (m *MockProjectManager) UpdateLines(ctx context.Context, projectId, path st
 	return m.UpdateLinesFunc(ctx, projectId, path, lineDiff)
 }
 
-func (m *MockProjectManager) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
-	return m.SearchSymbolsFunc(ctx, projectId, query)
+func (m *MockProjectManager) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error) {
+	return m.SearchSymbolsFunc(ctx, projectId, query, symbolFilter)
 }

--- a/pkg/project/mocks/mock_manager.go
+++ b/pkg/project/mocks/mock_manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/artmoskvin/hide/pkg/devcontainer"
 	"github.com/artmoskvin/hide/pkg/files"
+	"github.com/artmoskvin/hide/pkg/lsp"
 	"github.com/artmoskvin/hide/pkg/model"
 	"github.com/artmoskvin/hide/pkg/project"
 	"github.com/artmoskvin/hide/pkg/result"
@@ -24,7 +25,7 @@ type MockProjectManager struct {
 	ListFilesFunc        func(ctx context.Context, projectId string, showHidden bool) ([]*model.File, error)
 	ReadFileFunc         func(ctx context.Context, projectId, path string) (*model.File, error)
 	ResolveTaskAliasFunc func(ctx context.Context, projectId string, alias string) (devcontainer.Task, error)
-	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error)
+	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error)
 	UpdateFileFunc       func(ctx context.Context, projectId, path, content string) (*model.File, error)
 	UpdateLinesFunc      func(ctx context.Context, projectId, path string, lineDiff files.LineDiffChunk) (*model.File, error)
 }
@@ -85,6 +86,6 @@ func (m *MockProjectManager) UpdateLines(ctx context.Context, projectId, path st
 	return m.UpdateLinesFunc(ctx, projectId, path, lineDiff)
 }
 
-func (m *MockProjectManager) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]*model.File, error) {
+func (m *MockProjectManager) SearchSymbols(ctx context.Context, projectId model.ProjectId, query string) ([]lsp.SymbolInfo, error) {
 	return m.SearchSymbolsFunc(ctx, projectId, query)
 }


### PR DESCRIPTION
- new handler `/project/.../search?type=symbol&query=...&limit=10`
- powered by LSP servers
- filter out low level symbols like fields and variables from search results; currently hardcoded but can be exposed as a query parameter later