### PR TITLE
pkg/model: check if file contains new line before spliting

### DIFF
--- a/pkg/model/file.go
+++ b/pkg/model/file.go
@@ -124,7 +124,6 @@ func (f *File) ReplaceLineRange(start, end int, content string) (*File, error) {
 // NewFile creates a new File from the given path and content. Content is split into lines. Line numbers are 1-based.
 func NewFile(path string, content string) (*File, error) {
 	lines, err := NewLines(content)
-
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create lines from content: %w", err)
 	}
@@ -134,11 +133,14 @@ func NewFile(path string, content string) (*File, error) {
 
 // NewLines splits the given content into lines. Line numbers are 1-based.
 func NewLines(content string) ([]Line, error) {
-	var lines []Line
+	if !strings.Contains(content, "\n") {
+		return []Line{{Number: 1, Content: content}}, nil
+	}
 
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	lineNumber := 1
 
+	var lines []Line
 	for scanner.Scan() {
 		lines = append(lines, Line{Number: lineNumber, Content: scanner.Text()})
 		lineNumber++

--- a/pkg/model/file_test.go
+++ b/pkg/model/file_test.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"bufio"
+	"reflect"
+	"testing"
+)
+
+func TestNewLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []Line
+		wantErr bool
+	}{
+		{
+			name:    "with new lines",
+			content: "hey hey\nhey",
+			want:    []Line{{Number: 1, Content: "hey hey"}, {Number: 2, Content: "hey"}},
+			wantErr: false,
+		},
+		{
+			name:    "with escaped new lines",
+			content: "print('hey\\nhey')\nprint('bye')",
+			want:    []Line{{Number: 1, Content: "print('hey\\nhey')"}, {Number: 2, Content: "print('bye')"}},
+			wantErr: false,
+		},
+		{
+			name:    "with new lines",
+			content: string(make([]byte, bufio.MaxScanTokenSize+1)),
+			want:    []Line{{Number: 1, Content: string(make([]byte, bufio.MaxScanTokenSize+1))}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewLines(tt.content)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewLines() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("NewLines() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A patch to fix reads for large binary files. Will be handled more gracefully SOON!

Fixes #101 