### PR TITLE
pkg/model: remove bufio from NewLines()

### DIFF
--- a/pkg/files/manager.go
+++ b/pkg/files/manager.go
@@ -40,10 +40,7 @@ func (fm *FileManagerImpl) CreateFile(ctx context.Context, fs afero.Fs, path, co
 		return nil, NewFileAlreadyExistsError(path)
 	}
 
-	file, err := model.NewFile(path, content)
-	if err != nil {
-		return nil, err
-	}
+	file := model.NewFile(path, content)
 
 	dir := filepath.Dir(file.Path)
 	if err := fs.MkdirAll(dir, 0o755); err != nil {
@@ -80,10 +77,7 @@ func (fm *FileManagerImpl) UpdateFile(ctx context.Context, fs afero.Fs, path, co
 		return nil, NewFileNotFoundError(path)
 	}
 
-	file, err := model.NewFile(path, content)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create file: %w", err)
-	}
+	file := model.NewFile(path, content)
 
 	if err := writeFile(fs, file); err != nil {
 		return nil, fmt.Errorf("Failed to write file %s: %w", path, err)
@@ -241,7 +235,7 @@ func readFile(fs afero.Fs, path string) (*model.File, error) {
 		return nil, err
 	}
 
-	return model.NewFile(path, string(content))
+	return model.NewFile(path, string(content)), nil
 }
 
 func writeFile(fs afero.Fs, file *model.File) error {

--- a/pkg/files/manager_test.go
+++ b/pkg/files/manager_test.go
@@ -172,7 +172,7 @@ func TestFileManagerImpl_UpdateLines_Success(t *testing.T) {
 	tests := []struct {
 		name     string
 		lineDiff files.LineDiffChunk
-		expected model.File
+		expected *model.File
 	}{
 		{
 			name: "Update 1 line",
@@ -181,48 +181,25 @@ func TestFileManagerImpl_UpdateLines_Success(t *testing.T) {
 				EndLine:   2,
 				Content:   "line11",
 			},
-			expected: model.File{
-				Path: "test.txt",
-				Lines: []model.Line{
-					{Number: 1, Content: "line11"},
-					{Number: 2, Content: "line2"},
-					{Number: 3, Content: "line3"},
-				},
-			},
+			expected: model.NewFile("test.txt", "line11\nline2\nline3\n"),
 		},
 		{
 			name: "Update multiple lines",
 			lineDiff: files.LineDiffChunk{
 				StartLine: 1,
 				EndLine:   3,
-				Content:   "line11\nline12\n",
+				Content:   "line11\nline12",
 			},
-			expected: model.File{
-				Path: "test.txt",
-				Lines: []model.Line{
-					{Number: 1, Content: "line11"},
-					{Number: 2, Content: "line12"},
-					{Number: 3, Content: "line3"},
-				},
-			},
+			expected: model.NewFile("test.txt", "line11\nline12\nline3\n"),
 		},
 		{
 			name: "Add multiple lines at the end",
 			lineDiff: files.LineDiffChunk{
 				StartLine: 3,
 				EndLine:   4,
-				Content:   "line10\nline11\nline12\n",
+				Content:   "line10\nline11\nline12",
 			},
-			expected: model.File{
-				Path: "test.txt",
-				Lines: []model.Line{
-					{Number: 1, Content: "line1"},
-					{Number: 2, Content: "line2"},
-					{Number: 3, Content: "line10"},
-					{Number: 4, Content: "line11"},
-					{Number: 5, Content: "line12"},
-				},
-			},
+			expected: model.NewFile("test.txt", "line1\nline2\nline10\nline11\nline12\n"),
 		},
 	}
 
@@ -236,7 +213,7 @@ func TestFileManagerImpl_UpdateLines_Success(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			if !actual.Equals(&tt.expected) {
+			if !actual.Equals(tt.expected) {
 				t.Errorf("Expected %+v, got %+v", tt.expected, actual)
 			}
 		})
@@ -256,7 +233,7 @@ func TestFileManagerImpl_UpdateLines_Failure(t *testing.T) {
 				EndLine:   10,
 				Content:   "line11",
 			},
-			expected: "Start line must be less than or equal to 3",
+			expected: "Start line must be less than or equal to 4",
 		},
 		{
 			name: "End line > number of lines + 1",
@@ -265,7 +242,7 @@ func TestFileManagerImpl_UpdateLines_Failure(t *testing.T) {
 				EndLine:   11,
 				Content:   "line11",
 			},
-			expected: "End line must be less than or equal to 4",
+			expected: "End line must be less than or equal to 5",
 		},
 	}
 
@@ -290,12 +267,12 @@ func TestUpdateFile_Success(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
-		expected model.File
+		expected *model.File
 	}{
 		{
 			name:     "Update file",
 			content:  "line1\nline2\nline3\n",
-			expected: model.File{Path: "test.txt", Lines: []model.Line{{Number: 1, Content: "line1"}, {Number: 2, Content: "line2"}, {Number: 3, Content: "line3"}}},
+			expected: model.NewFile("test.txt", "line1\nline2\nline3\n"),
 		},
 	}
 
@@ -309,7 +286,7 @@ func TestUpdateFile_Success(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			if !actual.Equals(&tt.expected) {
+			if !actual.Equals(tt.expected) {
 				t.Errorf("Expected %+v, got %+v", tt.expected, actual)
 			}
 		})

--- a/pkg/files/manager_test.go
+++ b/pkg/files/manager_test.go
@@ -14,11 +14,11 @@ func TestReadFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	path := "test.txt"
 	content := "line1\nline2\nline3\n"
-	afero.WriteFile(fs, path, []byte(content), 0644)
+	afero.WriteFile(fs, path, []byte(content), 0o644)
 
 	fm := files.NewFileManager()
 	actual, err := fm.ReadFile(context.Background(), fs, path)
-	expected, _ := model.NewFile(path, content)
+	expected := model.NewFile(path, content)
 
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -31,7 +31,7 @@ func TestReadFile(t *testing.T) {
 
 func TestReadNonExistentFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	afero.WriteFile(fs, "test.txt", []byte("line1\nline2\nline3\n"), 0644)
+	afero.WriteFile(fs, "test.txt", []byte("line1\nline2\nline3\n"), 0o644)
 
 	fm := files.NewFileManager()
 	_, err := fm.ReadFile(context.Background(), fs, "non-existent.txt")
@@ -88,7 +88,7 @@ func TestFileManagerImpl_ApplyPatch_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filesystem := afero.NewMemMapFs()
-			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"), 0644)
+			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"), 0o644)
 			fm := files.NewFileManager()
 			actual, err := fm.ApplyPatch(context.Background(), filesystem, "test.txt", tt.patch)
 			if err != nil {
@@ -154,7 +154,7 @@ func TestFileManagerImpl_ApplyPatch_Failure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fileSystem := afero.NewMemMapFs()
-			afero.WriteFile(fileSystem, "test.txt", []byte("line1\nline2\nline3\n"), 0644)
+			afero.WriteFile(fileSystem, "test.txt", []byte("line1\nline2\nline3\n"), 0o644)
 			fm := files.NewFileManager()
 			_, err := fm.ApplyPatch(context.Background(), fileSystem, tt.file, tt.patch)
 			if err == nil {
@@ -230,7 +230,7 @@ func TestFileManagerImpl_UpdateLines_Success(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fm := files.NewFileManager()
 			filesystem := afero.NewMemMapFs()
-			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\n"), 0644)
+			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\n"), 0o644)
 			actual, err := fm.UpdateLines(context.Background(), filesystem, "test.txt", tt.lineDiff)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -272,7 +272,7 @@ func TestFileManagerImpl_UpdateLines_Failure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filesystem := afero.NewMemMapFs()
-			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\n"), 0644)
+			afero.WriteFile(filesystem, "test.txt", []byte("line1\nline2\nline3\n"), 0o644)
 			fm := files.NewFileManager()
 			_, err := fm.UpdateLines(context.Background(), filesystem, "test.txt", tt.lineDiff)
 			if err == nil {
@@ -302,7 +302,7 @@ func TestUpdateFile_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filesystem := afero.NewMemMapFs()
-			afero.WriteFile(filesystem, "test.txt", []byte("line11\nline12\n"), 0644)
+			afero.WriteFile(filesystem, "test.txt", []byte("line11\nline12\n"), 0o644)
 			fm := files.NewFileManager()
 			actual, err := fm.UpdateFile(context.Background(), filesystem, "test.txt", tt.content)
 			if err != nil {

--- a/pkg/handlers/create_file_test.go
+++ b/pkg/handlers/create_file_test.go
@@ -27,11 +27,11 @@ func TestCreateFileHandler(t *testing.T) {
 		{
 			name: "Success",
 			createFileFunc: func(ctx context.Context, projectId, path, content string) (*model.File, error) {
-				return model.NewFile("/test/path", "test content")
+				return model.NewFile("/test/path", "test content"), nil
 			},
 			requestBody: handlers.CreateFileRequest{Path: "/test/path", Content: "test content"},
 			wantStatus:  http.StatusCreated,
-			wantFile:    func() *model.File { f, _ := model.NewFile("/test/path", "test content"); return f }(),
+			wantFile:    func() *model.File { return model.NewFile("/test/path", "test content") }(),
 		},
 		{
 			name: "ProjectNotFound",

--- a/pkg/model/file.go
+++ b/pkg/model/file.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"bufio"
-	"fmt"
 	"strings"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -96,10 +94,7 @@ func (f *File) ReplaceLineRange(start, end int, content string) (*File, error) {
 		return f, nil
 	}
 
-	replacement, err := NewLines(content)
-	if err != nil {
-		return f, err
-	}
+	replacement := NewLines(content)
 
 	newLength := len(f.Lines) - (end - start) + len(replacement)
 	result := make([]Line, newLength)
@@ -122,31 +117,18 @@ func (f *File) ReplaceLineRange(start, end int, content string) (*File, error) {
 }
 
 // NewFile creates a new File from the given path and content. Content is split into lines. Line numbers are 1-based.
-func NewFile(path string, content string) (*File, error) {
-	lines, err := NewLines(content)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create lines from content: %w", err)
-	}
-
-	return &File{Path: path, Lines: lines}, nil
+func NewFile(path string, content string) *File {
+	return &File{Path: path, Lines: NewLines(content)}
 }
 
 // NewLines splits the given content into lines. Line numbers are 1-based.
-func NewLines(content string) ([]Line, error) {
-	if !strings.Contains(content, "\n") {
-		return []Line{{Number: 1, Content: content}}, nil
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	lineNumber := 1
-
+func NewLines(content string) []Line {
 	var lines []Line
-	for scanner.Scan() {
-		lines = append(lines, Line{Number: lineNumber, Content: scanner.Text()})
-		lineNumber++
+	for i, v := range strings.Split(content, "\n") {
+		lines = append(lines, Line{Number: i + 1, Content: v})
 	}
 
-	return lines, scanner.Err()
+	return lines
 }
 
 func EmptyFile(path string) *File {

--- a/pkg/model/file.go
+++ b/pkg/model/file.go
@@ -43,14 +43,11 @@ func (f *File) Equals(other *File) bool {
 }
 
 func (f *File) GetContent() string {
-	var content strings.Builder
-
-	for _, line := range f.Lines {
-		content.WriteString(line.Content)
-		content.WriteString("\n")
+	lines := make([]string, len(f.Lines))
+	for i, line := range f.Lines {
+		lines[i] = line.Content
 	}
-
-	return content.String()
+	return strings.Join(lines, "\n")
 }
 
 // GetLine returns the line with the given line number. Line numbers are 1-based.

--- a/pkg/model/file_test.go
+++ b/pkg/model/file_test.go
@@ -34,10 +34,7 @@ func TestNewLines(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewLines(tt.content)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("NewLines() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			got := NewLines(tt.content)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("NewLines() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Typically `bufio` is used when riding directly from a file (local/remove). It helps to optimise reads, by reading in chunks corresponding to a buffer size. In our case, the data is already read and is in memory. Simple string split should do the job and help to avoid issues like #101. Also I think it would be more efficient. 